### PR TITLE
fix(build): pin @semantic-release/github to 5.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@adobe/eslint-config-helix": "^1.0.0",
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/git": "7.0.15",
-    "@semantic-release/github": "^5.2.10",
+    "@semantic-release/github": "5.4.2",
     "chai": "^4.2.0",
     "codecov": "3.5.0",
     "commitizen": "^4.0.0",


### PR DESCRIPTION
Fixes #57 